### PR TITLE
Clean up `<include>`s

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <list>
+#include <utility>
 #include <rectpack2D/finders_interface.h>
 
 /* For description of the algorithm, please see the README.md */

--- a/src/rectpack2D/best_bin_finder.h
+++ b/src/rectpack2D/best_bin_finder.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <variant>
 #include <cassert>
-#include <algorithm>
+#include <optional>
 #include "rect_structs.h"
 
 namespace rectpack2D {

--- a/src/rectpack2D/empty_space_allocators.h
+++ b/src/rectpack2D/empty_space_allocators.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <array>
 #include <vector>
-
 #include "rect_structs.h"
 
 namespace rectpack2D {

--- a/src/rectpack2D/empty_space_allocators.h
+++ b/src/rectpack2D/empty_space_allocators.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <array>
 #include <vector>
-#include <type_traits>
 
 #include "rect_structs.h"
 

--- a/src/rectpack2D/empty_spaces.h
+++ b/src/rectpack2D/empty_spaces.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <optional>
 #include "insert_and_split.h"
 
 namespace rectpack2D {

--- a/src/rectpack2D/finders_interface.h
+++ b/src/rectpack2D/finders_interface.h
@@ -1,16 +1,8 @@
 #pragma once
-#include <optional>
-#include <vector>
-#include <array>
-#include <variant>
 #include <memory>
-#include <algorithm>
-
-#include "insert_and_split.h"
 #include "empty_spaces.h"
-#include "empty_space_allocators.h"
-
 #include "best_bin_finder.h"
+#include "empty_space_allocators.h" // IWYU pragma: export
 
 namespace rectpack2D {
 	template <class empty_spaces_type>

--- a/src/rectpack2D/rect_structs.h
+++ b/src/rectpack2D/rect_structs.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <utility>
+#include <algorithm>
 
 namespace rectpack2D {
 	using total_area_type = int;


### PR DESCRIPTION
There are some unnecessary/misplaced headers in `finders_interface.h` that emit warnings. This PR aims to:
- remove unnecessary headers,
- move necessary headers to where they're needed, and include them transitively, and
- "decorate" technically unused, yet necessary-for-usage headers with `// IWYU pragma: export`.

I've also removed the `<list>` header from `example/main.cpp` (if anyone wants to try out the API with `std::list`, they can add it themselves), and added `<utility>` for `std::as_const()`.

<img width="1243" height="346" alt="image" src="https://github.com/user-attachments/assets/ec5f6b7c-2912-47ac-8e30-1c441c133a45" />

This is another minor edit to the code, but I think eliminating these warnings is worth it for further development.
**Not tested yet on GCC/MSVC**, I'll get to that soon (although CI/CD should tell us whether it compiles). The only caveat I can think of right now is that existing codebases could have unintentionally relied upon rectpack2D bringing in `<utility>`, the only actually unused header that has been removed.